### PR TITLE
Add reproducible build around the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+
+result

--- a/0001-patch-csproj-to-find-the-openxml-dll.patch
+++ b/0001-patch-csproj-to-find-the-openxml-dll.patch
@@ -1,0 +1,52 @@
+From 8c764df6ad27d08b207029879f63d59838c6b53d Mon Sep 17 00:00:00 2001
+From: Jappie Klooster <jappieklooster@hotmail.com>
+Date: Mon, 25 Jul 2022 13:36:18 +0200
+Subject: [PATCH] patch csproj to find the openxml dll
+
+---
+ XlsxValidator.csproj | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/XlsxValidator.csproj b/XlsxValidator.csproj
+index 06bba76..272b4b5 100644
+--- a/XlsxValidator.csproj
++++ b/XlsxValidator.csproj
+@@ -53,7 +53,7 @@
+     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
+       <ItemGroup>
+         <Reference Include="DocumentFormat.OpenXml">
+-          <HintPath>..\packages\DocumentFormat.OpenXml\lib\net35\DocumentFormat.OpenXml.dll</HintPath>
++          <HintPath>lib\dotnet\DocumentFormat.OpenXml\net35\DocumentFormat.OpenXml.dll</HintPath>
+           <Private>True</Private>
+           <Paket>True</Paket>
+         </Reference>
+@@ -62,7 +62,7 @@
+     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')">
+       <ItemGroup>
+         <Reference Include="DocumentFormat.OpenXml">
+-          <HintPath>..\packages\DocumentFormat.OpenXml\lib\net40\DocumentFormat.OpenXml.dll</HintPath>
++          <HintPath>lib\dotnet\DocumentFormat.OpenXml\net40\DocumentFormat.OpenXml.dll</HintPath>
+           <Private>True</Private>
+           <Paket>True</Paket>
+         </Reference>
+@@ -71,7 +71,7 @@
+     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
+       <ItemGroup>
+         <Reference Include="DocumentFormat.OpenXml">
+-          <HintPath>..\packages\DocumentFormat.OpenXml\lib\net46\DocumentFormat.OpenXml.dll</HintPath>
++          <HintPath>lib\dotnet\DocumentFormat.OpenXml\net46\DocumentFormat.OpenXml.dll</HintPath>
+           <Private>True</Private>
+           <Paket>True</Paket>
+         </Reference>
+@@ -80,7 +80,7 @@
+     <When Condition="($(TargetFrameworkIdentifier) == '.NETStandard' And ($(TargetFrameworkVersion) == 'v1.3' Or $(TargetFrameworkVersion) == 'v1.4' Or $(TargetFrameworkVersion) == 'v1.5' Or $(TargetFrameworkVersion) == 'v1.6')) Or ($(TargetFrameworkIdentifier) == '.NETCoreApp' And $(TargetFrameworkVersion) == 'v1.0')">
+       <ItemGroup>
+         <Reference Include="DocumentFormat.OpenXml">
+-          <HintPath>..\packages\DocumentFormat.OpenXml\lib\netstandard1.3\DocumentFormat.OpenXml.dll</HintPath>
++          <HintPath>lib\dotnet\DocumentFormat.OpenXml\netstandard1.3\DocumentFormat.OpenXml.dll</HintPath>
+           <Private>True</Private>
+           <Paket>True</Paket>
+         </Reference>
+-- 
+2.33.3
+

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,43 @@
+/*
+some_program/default.nix
+nix-build -E 'with import <nixpkgs> { }; callPackage ./default.nix { }'
+*/
+
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchNuGet
+, buildDotnetPackage
+, dotnetPackages
+, pkg-config
+, callPackage
+}:
+let
+  openxml = callPackage ./nix/openxml.nix {};
+in
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/dotnet/build-dotnet-package/default.nix
+buildDotnetPackage rec {
+  pname = "xlsx-validator";
+  baseName = pname; # workaround for "called without baseName"
+  version = "1.0";
+  src = ./XlsxValidator;
+  projectFile = ["./XlsxValidator.csproj"];
+
+
+  # we patch in the openxml ref by hand,
+  # nix doesn't appear to do depencencies yet
+  preBuild = ''
+   set -xe
+   cp -r ${openxml}/lib ./lib
+   ls
+   ls ./lib/dotnet/DocumentFormat.OpenXml
+  '';
+  nativeBuildInputs = [
+    pkg-config
+  ];
+  meta = {
+    homepage = "some_homepage";
+    description = "some_description";
+    license = lib.licenses.mit;
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,8 @@ buildDotnetPackage rec {
   src = ./XlsxValidator;
   projectFile = ["./XlsxValidator.csproj"];
 
+  patches = [ ./0001-patch-csproj-to-find-the-openxml-dll.patch];
+
 
   # we patch in the openxml ref by hand,
   # nix doesn't appear to do depencencies yet

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -1,0 +1,6 @@
+# convenience insta build script
+let
+  pkgs = import ./pin.nix {};
+in
+pkgs.callPackage ../default.nix {}
+# pkgs.callPackage ./openxml.nix {}

--- a/nix/openxml.nix
+++ b/nix/openxml.nix
@@ -1,0 +1,13 @@
+/*
+get's openxml
+*/
+{ fetchNuGet,
+}:
+
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/dotnet/build-dotnet-package/default.nix
+fetchNuGet {
+    pname = "DocumentFormat.OpenXml";
+    version = "2.8.1";
+    sha256 = "08r7farkimmr0r7vjkdmc6a6vdz33smfc2si8zs5kf85c7l9nc67";
+    outputFiles = [ "lib/*" ];
+    }

--- a/nix/openxml.nix
+++ b/nix/openxml.nix
@@ -4,10 +4,10 @@ get's openxml
 { fetchNuGet,
 }:
 
-# https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/dotnet/build-dotnet-package/default.nix
+# https://www.nuget.org/packages/DocumentFormat.OpenXml
 fetchNuGet {
     pname = "DocumentFormat.OpenXml";
-    version = "2.8.1";
-    sha256 = "08r7farkimmr0r7vjkdmc6a6vdz33smfc2si8zs5kf85c7l9nc67";
+    version = "2.17.1";
+    sha256 = "05fcyh53hz6m45pgq49lvgaz9a150hkgl66xx6i4inaax9kcpr46";
     outputFiles = [ "lib/*" ];
     }

--- a/nix/pin.nix
+++ b/nix/pin.nix
@@ -1,0 +1,6 @@
+import (builtins.fetchGit {
+    # Descriptive name to make the store path easier to identify
+    name = "nixos-pin-2022.05.07";
+    url = "https://github.com/nixos/nixpkgs/";
+    rev = "18854d7bbc472919eace2303779d1653a78bd63b";
+    })

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+let
+  pkgs = import ./nix/pin.nix {};
+in
+pkgs.mkShell {
+  buildInputs = [pkgs.dotnet-sdk];
+}


### PR DESCRIPTION
This makes building the project reproducible through [nix](https://nixos.org/).
Supercede will use this project to validate outgoing excell files to make sure
our custom excell generation code is correct.